### PR TITLE
A wrapper object to instantiate a virtual dom

### DIFF
--- a/vDOM.js
+++ b/vDOM.js
@@ -1,0 +1,26 @@
+var diff = require("./diff.js")
+var patch = require("./patch.js")
+var h = require("./h.js")
+var create = require("./create-element.js")
+
+function vDOM(){
+    
+  var tree = h('#root','');
+  var rootNode = create(tree);
+  document.body.appendChild(rootNode);
+
+  function update(newTree){
+    var patches = diff(tree, newTree);
+    rootNode = patch(rootNode, patches);
+    tree = newTree;
+  }
+  
+  return{
+      
+    render: function(tree){
+      update(tree);
+    }
+     
+  };
+    
+}


### PR DESCRIPTION
Instead of writing setup code to load and update the virtual dom, just instantiate vDOM and call vDOM.render( newTree ) to diff and patch.

This is for browser-use only, as the 'document' object is called.